### PR TITLE
Add support for value functions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,9 @@ module.exports = (options = {}) => (fn, args = []) => {
 
       if (response && response.then) {
         response.then(callback.bind(null, null), callback);
+      } 
+      if (response && !response.then) {
+        callback(null, response);
       }
     }, (err, res) => (err ? reject(err) : resolve(res)));
 

--- a/test/retry.test.js
+++ b/test/retry.test.js
@@ -61,4 +61,10 @@ describe('Retry', () => {
     }
     expect(this.counter, 'to equal', 1);
   });
+
+  it('should support value functions without callback', async () => {
+    const retry = createRetry(defaultOptions);
+    const result = await retry(() => 'foobar');
+    expect(result, 'to equal', 'foobar');
+  })
 });


### PR DESCRIPTION
Retry does not support simple value functions. This PR adds support for this. 